### PR TITLE
chore: add Supabase keep-alive workflow and helper script

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,36 @@
+Keep Supabase Alive workflow
+===========================
+
+This repository contains a GitHub Actions workflow that periodically pings your Supabase project's health endpoint to keep the project active.
+
+Workflow file:
+
+- `.github/workflows/keep-supabase-alive.yml`
+
+Required repository secrets
+---------------------------
+
+You must add the following repository secrets (Actions → Secrets and variables → Actions):
+
+- `SUPABASE_URL` — your Supabase project URL, e.g. `https://buqkvkzderfmhsqxgkeb.supabase.co`
+- `SUPABASE_ANON_KEY` — your Supabase anon/public key (same as `NEXT_PUBLIC_SUPABASE_ANON_KEY` locally)
+
+Quick manual steps (GitHub UI)
+-----------------------------
+1. Open your GitHub repository page.
+2. Settings → Secrets and variables → Actions → New repository secret.
+3. Add `SUPABASE_URL` and `SUPABASE_ANON_KEY` with values from your local `.env.local`.
+
+Optional: automate with GitHub CLI
+----------------------------------
+If you have the GitHub CLI (`gh`) installed and authenticated, you can run the helper script at the repo root to set secrets automatically from your local `.env.local` file:
+
+PowerShell (Windows) — run in repository root:
+
+pwsh ./scripts/set-github-secrets.ps1
+
+Notes
+-----
+- The workflow only uses repository secrets; no keys are committed to the repo.
+- If secrets are missing, the workflow will fail early with a helpful message visible on the Actions run page.
+- If you accidentally pushed keys to the repo in the past, rotate them in Supabase immediately.

--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,37 @@
+name: Keep Supabase Alive
+
+on:
+  schedule:
+    - cron: '0 */12 * * *' # Runs every 12 hours
+  workflow_dispatch:     # Allow manual run
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase health endpoint
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          # Fail fast with a helpful message if secrets aren't set
+          if [ -z "$SUPABASE_URL" ]; then
+            echo "Error: SUPABASE_URL secret is not set"
+            exit 1
+          fi
+          if [ -z "$SUPABASE_ANON_KEY" ]; then
+            echo "Error: SUPABASE_ANON_KEY secret is not set"
+            exit 1
+          fi
+
+          # Ensure URL has no trailing slash, then call the health endpoint
+          HEALTH_URL="${SUPABASE_URL%/}/rest/v1/health"
+          echo "Pinging $HEALTH_URL"
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "apikey: $SUPABASE_ANON_KEY" "$HEALTH_URL")
+          echo "Health endpoint returned HTTP $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+            echo "Supabase ping successful"
+          else
+            echo "Supabase ping failed"
+            exit 1
+          fi

--- a/scripts/set-github-secrets.ps1
+++ b/scripts/set-github-secrets.ps1
@@ -1,0 +1,54 @@
+<#
+Reads .env.local in the repository root and sets two GitHub Actions repository secrets
+using the GitHub CLI (`gh`).
+
+Requirements:
+- GitHub CLI (`gh`) installed and authenticated (`gh auth login`).
+- Run this script from the repository root.
+
+Usage:
+pwsh ./scripts/set-github-secrets.ps1
+#>
+
+$envFile = Join-Path $PSScriptRoot '..' '.env.local' | Resolve-Path -ErrorAction SilentlyContinue
+if (-not $envFile) {
+    Write-Error ".env.local not found in repository root. Create the file with SUPABASE values and retry."
+    exit 1
+}
+
+$lines = Get-Content $envFile
+$map = @{}
+foreach ($line in $lines) {
+    if ($line -match '^\s*#') { continue }
+    if ($line -match '^\s*$') { continue }
+    $parts = $line -split '=', 2
+    if ($parts.Count -ne 2) { continue }
+    $key = $parts[0].Trim()
+    $val = $parts[1].Trim()
+    $map[$key] = $val
+}
+
+if (-not $map.ContainsKey('NEXT_PUBLIC_SUPABASE_URL')) {
+    Write-Error "NEXT_PUBLIC_SUPABASE_URL not found in .env.local"
+    exit 1
+}
+if (-not $map.ContainsKey('NEXT_PUBLIC_SUPABASE_ANON_KEY')) {
+    Write-Error "NEXT_PUBLIC_SUPABASE_ANON_KEY not found in .env.local"
+    exit 1
+}
+
+Write-Host "Setting repository secrets using gh (requires gh auth)."
+Write-Host "Repository: will use current repository context from gh if available."
+
+$supabaseUrl = $map['NEXT_PUBLIC_SUPABASE_URL']
+$supabaseAnon = $map['NEXT_PUBLIC_SUPABASE_ANON_KEY']
+
+Write-Host "Setting SUPABASE_URL..."
+gh secret set SUPABASE_URL --body $supabaseUrl
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set SUPABASE_URL"; exit 1 }
+
+Write-Host "Setting SUPABASE_ANON_KEY..."
+gh secret set SUPABASE_ANON_KEY --body $supabaseAnon
+if ($LASTEXITCODE -ne 0) { Write-Error "Failed to set SUPABASE_ANON_KEY"; exit 1 }
+
+Write-Host "Secrets set. Verify in GitHub → Settings → Secrets and variables → Actions."


### PR DESCRIPTION
Adds a GitHub Actions workflow that pings the Supabase health endpoint every 12 hours and a helper PowerShell script to set the required repository secrets via the GitHub CLI.\n\nFiles: .github/workflows/keep-supabase-alive.yml, .github/workflows/README.md, scripts/set-github-secrets.ps1